### PR TITLE
sketch some much simpler API for some parts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ rand = "0.8.3"
 # sesh = "0.1.1"
 mpst-seq = { git = "https://github.com/NicolasLagaillardie/mpst-seq", branch = "main"}
 # mpst-seq = { path = "../mpst-seq" }
+anyhow = "1"
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/examples/rk.rs
+++ b/examples/rk.rs
@@ -1,0 +1,127 @@
+use anyhow::{anyhow, Result};
+use crossbeam_channel::{select, unbounded, Receiver, Sender};
+use std::{marker::PhantomData, thread::spawn};
+
+struct Channel<To> {
+    pub rx: Receiver<u32>,
+    pub tx: Sender<u32>,
+    _ph: PhantomData<To>,
+}
+
+fn mk_chan<A, B>() -> (Channel<B>, Channel<A>) {
+    let (tx_to, rx_to) = unbounded();
+    let (tx_fro, rx_fro) = unbounded();
+    (
+        Channel {
+            rx: rx_fro,
+            tx: tx_to,
+            _ph: PhantomData,
+        },
+        Channel {
+            rx: rx_to,
+            tx: tx_fro,
+            _ph: PhantomData,
+        },
+    )
+}
+
+struct Tx<Role, Cont> {
+    cont: Cont,
+    _ph: PhantomData<Role>,
+}
+struct Rx<Role, Cont> {
+    cont: Cont,
+    _ph: PhantomData<Role>,
+}
+struct End;
+
+/// The local code can use either left or right, which will in any case consume the Choice.
+struct MyChoice<C1, C2> {
+    left: C1,
+    right: C2,
+}
+/// This node allows receiving from either R1 or R2, depending on an external choice
+struct TheirChoice<R1, C1, R2, C2> {
+    left: C1,
+    right: C2,
+    _ph: PhantomData<(R1, R2)>,
+}
+enum ChoiceResult<C1, C2> {
+    Left(u32, C1),
+    Right(u32, C2),
+}
+
+impl<R1, C1, R2, C2> TheirChoice<R1, C1, R2, C2> {
+    pub fn recv(self, left: Channel<R1>, right: Channel<R2>) -> Result<ChoiceResult<C1, C2>> {
+        select! {
+            recv(left.rx) -> msg => Ok(ChoiceResult::Left(msg?, self.left)),
+            recv(right.rx) -> msg => Ok(ChoiceResult::Right(msg?, self.right)),
+        }
+    }
+}
+
+impl<Role, Cont> Tx<Role, Cont> {
+    pub fn send(self, channel: Channel<Role>, value: u32) -> Result<Cont> {
+        channel.tx.send(value)?;
+        Ok(self.cont)
+    }
+}
+fn tx<R, C>(_role: R, cont: C) -> Tx<R, C> {
+    Tx {
+        cont,
+        _ph: PhantomData,
+    }
+}
+
+impl<Role, Cont> Rx<Role, Cont> {
+    pub fn recv(self, channel: Channel<Role>) -> Result<(u32, Cont)> {
+        let ret = channel.rx.recv()?;
+        Ok((ret, self.cont))
+    }
+}
+fn rx<R, C>(_role: R, cont: C) -> Rx<R, C> {
+    Rx {
+        cont,
+        _ph: PhantomData,
+    }
+}
+
+struct RoleA;
+struct RoleB;
+struct RoleC;
+
+fn fancy_building_block<Cont>(
+    to_a: Channel<RoleA>,
+    to_b: Channel<RoleB>,
+    p: Tx<RoleA, Rx<RoleB, Cont>>,
+) -> Result<Cont> {
+    Ok(p.send(to_a, 55)?.recv(to_b)?.1)
+}
+
+fn main() -> Result<()> {
+    let prot_a = tx(RoleB, rx(RoleC, End));
+    let prot_b = rx(RoleA, tx(RoleC, End));
+    let prot_c = rx(RoleB, tx(RoleA, End));
+
+    let (ch_ab, ch_ba) = mk_chan::<RoleA, RoleB>();
+    let (ch_ac, ch_ca) = mk_chan::<RoleA, RoleC>();
+    let (ch_bc, ch_cb) = mk_chan::<RoleB, RoleC>();
+
+    let thread_a = spawn(move || prot_a.send(ch_ab, 42)?.recv(ch_ac));
+    let thread_b = spawn(move || {
+        let (value, p) = prot_b.recv(ch_ba)?;
+        p.send(ch_bc, value)
+    });
+    let thread_c = spawn(move || {
+        let (value, p) = prot_c.recv(ch_cb)?;
+        p.send(ch_ca, value)
+    });
+
+    let (x, _end): (u32, End) = thread_a.join().map_err(|x| anyhow!("{:?}", x))??;
+    let _end: End = thread_b.join().map_err(|x| anyhow!("{:?}", x))??;
+    let _end: End = thread_c.join().map_err(|x| anyhow!("{:?}", x))??;
+
+    println!("result: {}", x);
+
+    Ok(())
+}


### PR DESCRIPTION
@NicolasLagaillardie When playing with your branch I found it difficult to use VS Code due to the abundance of macros. I also find that there are way too many names assigned, so I tried out a minimalistic example of a different API design. What I tried so far does not include recursion, which may make some things a bit harder, but I hope that much of the simplicity can be kept.

The idea is that the only required user-defined names are for the roles. A channel is parameterised with the remote role it connects to — since all types within Rust are local projections the local role is fixed implicitly. A session describes receive and send operations together with the roles they interact with, constructed as a (zero-sized) value that is passed around without cost.

This approach makes it possible to offer tab-completion on the current local session to see what the next required step is. All types are resolved successfully in VS Code and there shouldn’t be much worry regarding compilation times since the amount of code is low and type signatures are not complex.

---

One remark on the example code in your branch: Rust does not have tail-call elimination (at least not guaranteed, and I think not for co-recursion), so your examples are not stack-safe. This is why I prefer to return the continuation to the caller everywhere. You can see an example in `fancy_building_block`, a function that declares only some part of a protocol.